### PR TITLE
fixing a typo in the name of dependency object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ jdk:
 branches:
   only:
   - master
-sudo: required
 before_script:
 - if [ $TRAVIS_PULL_REQUEST = 'false' ]; then git checkout -qf $TRAVIS_BRANCH; fi
 - if [ $TRAVIS_PULL_REQUEST = 'false' ]; then git config --local user.name impulso-io;

--- a/src/main/scala/dependencies.scala
+++ b/src/main/scala/dependencies.scala
@@ -2,7 +2,7 @@ package pulse.plugin
 
 import sbt._, Keys._
 
-object depenendencies {
+object dependencies {
 
   def _test     (module: ModuleID): ModuleID = module % "test"
   def _provided (module: ModuleID): ModuleID = module % "provided"


### PR DESCRIPTION
 - fixing a typo in the name of dependencies package
 - removing sudo requirements from travis in order to switch to container-based builds (which are faster to spawn)